### PR TITLE
Update editorconfig indent rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,13 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{**.{py,json,yml}}]
+[{**.{py,json}}]
 indent_style = space
 indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
 
 [*.md]
 indent_style = space


### PR DESCRIPTION
## Summary
- fix indentation config for Python and JSON
- specify YAML indentation rules

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68556e67afec832f976d478afd431c35