### PR TITLE
[GIT] Use color UI, use tabs in the config

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,6 +3,8 @@
 	# machine specific settings
 [core]
 	excludesfile = ~/.gitignore_global
+[color]
+	ui = auto
 [credential]
 	helper = store
 [alias]


### PR DESCRIPTION
- enable git color output by default in `.gitconfig`
- ensure tabs are used for indentation