### PR TITLE
Add flake8 configuration

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,4 +15,4 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8
     - name: Run linter
-      run: python -m flake8 --max-line-length 120 --show-source
+      run: python -m flake8 --show-source

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
## Summary
- configure Flake8 using `setup.cfg`
- remove `.flake8`
- update GitHub Actions workflow to rely on the configuration file

## Testing
- `python3 -m py_compile deploy.py update.py`
- `pip install flake8 --user` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688504d40034832f8217e395c0eca2f7